### PR TITLE
fix(open-telemetry-nest): add context to log emission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18154,8 +18154,10 @@
     "packages/open-telemetry-nest": {
       "name": "@zonneplan/open-telemetry-nest",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^10.3.3",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/api-logs": "^0.49.1",
         "@opentelemetry/exporter-prometheus": "^0.49.1",
         "@opentelemetry/sdk-metrics": "^1.22.0",
@@ -18171,6 +18173,7 @@
     "packages/open-telemetry-node": {
       "name": "@zonneplan/open-telemetry-node",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/api-logs": "^0.49.1",
@@ -18194,6 +18197,7 @@
     "packages/open-telemetry-zonneplan": {
       "name": "@zonneplan/open-telemetry-zonneplan",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^10.3.4",
         "@opentelemetry/auto-instrumentations-node": "^0.43.0",

--- a/packages/open-telemetry-nest/package.json
+++ b/packages/open-telemetry-nest/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "dependencies": {
     "@nestjs/common": "^10.3.3",
+    "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/api-logs": "^0.49.1",
     "@opentelemetry/exporter-prometheus": "^0.49.1",
     "@opentelemetry/sdk-metrics": "^1.22.0",

--- a/packages/open-telemetry-nest/src/logging/adapters/nest-winston-logger.adapter.ts
+++ b/packages/open-telemetry-nest/src/logging/adapters/nest-winston-logger.adapter.ts
@@ -5,6 +5,7 @@ import { Logger } from 'winston';
 import { GlobalProviders } from '@zonneplan/open-telemetry-node';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { LoggerService } from '../services/logger.service';
+import { context } from '@opentelemetry/api';
 
 /**
  * @see https://github.com/winstonjs/winston?tab=readme-ov-file#logging
@@ -101,7 +102,7 @@ export class NestWinstonLoggerAdapter extends LoggerService {
   public override setLogLevels(_: LogLevel[]): any {
     // ignored
   }
-
+  
   private emitLog(
     severityNumber: SeverityNumber,
     body: any,
@@ -134,7 +135,8 @@ export class NestWinstonLoggerAdapter extends LoggerService {
       severityNumber,
       body,
       severityText,
-      attributes
+      attributes,
+      context: context.active()
     });
   }
 }


### PR DESCRIPTION
The logger adapter missed log correlation. By adding the context, we now include the trace/span information in the log message.