### PR TITLE
refactor(logging): moved constants to separate file

### DIFF
--- a/packages/open-telemetry-nest/src/logging/adapters/nest-winston-logger.adapter.ts
+++ b/packages/open-telemetry-nest/src/logging/adapters/nest-winston-logger.adapter.ts
@@ -6,28 +6,8 @@ import { GlobalProviders } from '@zonneplan/open-telemetry-node';
 import { LogAttributes, SeverityNumber } from '@opentelemetry/api-logs';
 import { LoggerService } from '../services/logger.service';
 import { context } from '@opentelemetry/api';
+import { NEST_LOG_LEVEL_WINSTON_SEVERITY, SEVERITY_TEXT_TO_NEST_LOG_LEVEL } from '../constants';
 
-/**
- * @see https://github.com/winstonjs/winston?tab=readme-ov-file#logging
- */
-const NEST_LOG_LEVEL_WINSTON_SEVERITY: Record<LogLevel, number> = {
-  fatal: 0,
-  error: 0,
-  warn: 1,
-  log: 2,
-  verbose: 4,
-  debug: 5
-};
-
-const SEVERITY_TEXT_TO_NEST_LOG_LEVEL: Record<string, LogLevel> = {
-  FATAL: 'fatal',
-  ERROR: 'error',
-  WARN: 'warn',
-  INFO: 'log',
-  DEBUG: 'debug',
-  TRACE: 'verbose',
-  UNSPECIFIED: 'log'
-};
 
 export class NestWinstonLoggerAdapter extends LoggerService {
   private severityNumberToSeverityTextMap: Record<number, string> = {
@@ -127,7 +107,7 @@ export class NestWinstonLoggerAdapter extends LoggerService {
 
     const winstonLogLevel = this.toWinstonLogLevel(nestLogLevel);
     this.logger[winstonLogLevel](body, attributes);
-    
+
     if (!GlobalProviders.logProvider) {
       console.error('OpenTelemetry log provider not initialized');
       return;

--- a/packages/open-telemetry-nest/src/logging/constants.ts
+++ b/packages/open-telemetry-nest/src/logging/constants.ts
@@ -1,0 +1,23 @@
+import { LogLevel } from '@nestjs/common';
+
+/**
+ * @see https://github.com/winstonjs/winston?tab=readme-ov-file#logging
+ */
+export const NEST_LOG_LEVEL_WINSTON_SEVERITY: Record<LogLevel, number> = {
+  fatal: 0,
+  error: 0,
+  warn: 1,
+  log: 2,
+  verbose: 4,
+  debug: 5
+};
+
+export const SEVERITY_TEXT_TO_NEST_LOG_LEVEL: Record<string, LogLevel> = {
+  FATAL: 'fatal',
+  ERROR: 'error',
+  WARN: 'warn',
+  INFO: 'log',
+  DEBUG: 'debug',
+  TRACE: 'verbose',
+  UNSPECIFIED: 'log'
+};


### PR DESCRIPTION
Moved constants to a separate file. This makes the nest log adapter a bit more readable, but it is also really useful for testing to new release pipeline :)