### PR TITLE
feat(open-telemetry-node): enable diag logging

### DIFF
--- a/examples/nest-app/src/main.ts
+++ b/examples/nest-app/src/main.ts
@@ -10,6 +10,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import * as process from 'node:process';
 import { LoggerFactory } from '@zonneplan/open-telemetry-zonneplan';
+import { DiagLogLevel } from '@zonneplan/open-telemetry-node';
 
 new otel.OpenTelemetryBuilder('nest-example')
   .withTracing(zonneplan.DefaultTracingOptions)
@@ -20,7 +21,7 @@ new otel.OpenTelemetryBuilder('nest-example')
       metricsOptions.withMetricReader(new nest.PrometheusNestExporter())
     )
   )
-  // .withDebugLogging()
+  .withDiagLogging(DiagLogLevel.WARN)
   .start();
 
 async function bootstrap() {

--- a/packages/open-telemetry-node/src/core/index.ts
+++ b/packages/open-telemetry-node/src/core/index.ts
@@ -1,5 +1,10 @@
+import { DiagLogLevel } from '@opentelemetry/api';
+
 // Builders
 export {
   type IOpenTelemetryBuilder,
   OpenTelemetryBuilder
 } from './builders/open-telemetry.builder';
+
+// Enums
+export { DiagLogLevel };


### PR DESCRIPTION
Added a new method on the OTEL builder to add diagnostics logging with a desired log level. The enableDebugLogging will soon be deprecated once we release the initial v1.0.