### PR TITLE
fix(open-telemetry-node): removed duplicate trace provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19779,7 +19779,7 @@
     },
     "packages/open-telemetry-nest": {
       "name": "@zonneplan/open-telemetry-nest",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^10.3.3",
@@ -19796,10 +19796,10 @@
         "jest-mock-extended": "^3.0.5"
       }
     },
-    "packages/open-telemetry-node": {
-      "name": "@zonneplan/open-telemetry-node",
+    "packages/open-telemetry-nest/node_modules/@zonneplan/open-telemetry-node": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@zonneplan/open-telemetry-node/-/open-telemetry-node-0.1.0.tgz",
+      "integrity": "sha512-M0st8Ymvjaq2IMNVrt0UdsJmdy+nTeGf63uJa6hErxW11th15keocPDQsUaTcLgNT48wEoc5wZBmDL0Itsei5w==",
       "dependencies": {
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/api-logs": "^0.49.1",
@@ -19815,6 +19815,26 @@
         "prom-client": "^15.1.0",
         "reflect-metadata": "^0.1.14",
         "tslib": "^2.3.0"
+      }
+    },
+    "packages/open-telemetry-node": {
+      "name": "@zonneplan/open-telemetry-node",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/core": "^1.22.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/resources": "^1.22.0",
+        "@opentelemetry/sdk-logs": "^0.49.1",
+        "@opentelemetry/sdk-metrics": "^1.22.0",
+        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-trace-base": "^1.22.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
+        "prom-client": "^15.1.0",
+        "reflect-metadata": "^0.1.14",
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "jest-mock-extended": "^3.0.5"
@@ -19822,7 +19842,7 @@
     },
     "packages/open-telemetry-zonneplan": {
       "name": "@zonneplan/open-telemetry-zonneplan",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^10.3.4",
@@ -19856,6 +19876,27 @@
         "prom-client": "^15.1.0",
         "tslib": "^2.3.0",
         "winston": "^3.12.0"
+      }
+    },
+    "packages/open-telemetry-zonneplan/node_modules/@zonneplan/open-telemetry-node": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@zonneplan/open-telemetry-node/-/open-telemetry-node-0.1.0.tgz",
+      "integrity": "sha512-M0st8Ymvjaq2IMNVrt0UdsJmdy+nTeGf63uJa6hErxW11th15keocPDQsUaTcLgNT48wEoc5wZBmDL0Itsei5w==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/core": "^1.22.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/resources": "^1.22.0",
+        "@opentelemetry/sdk-logs": "^0.49.1",
+        "@opentelemetry/sdk-metrics": "^1.22.0",
+        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-trace-base": "^1.22.0",
+        "@opentelemetry/sdk-trace-node": "^1.22.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
+        "prom-client": "^15.1.0",
+        "reflect-metadata": "^0.1.14",
+        "tslib": "^2.3.0"
       }
     }
   }

--- a/packages/open-telemetry-node/package.json
+++ b/packages/open-telemetry-node/package.json
@@ -12,7 +12,6 @@
     "@opentelemetry/sdk-metrics": "^1.22.0",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
-    "@opentelemetry/sdk-trace-node": "^1.22.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "prom-client": "^15.1.0",
     "reflect-metadata": "^0.1.14",

--- a/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
+++ b/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
@@ -4,8 +4,6 @@ import {
   OpenTelemetryTracingOptions,
   OpenTelemetryTracingOptionsBuilder
 } from '../../tracing';
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { detectResourcesSync, envDetector, IResource, Resource } from '@opentelemetry/resources';
 import {
   IOpenTelemetryMetricsOptionsBuilder,
@@ -29,6 +27,7 @@ import {
   SEMRESATTRS_SERVICE_NAME
 } from '@opentelemetry/semantic-conventions/build/src/resource/SemanticResourceAttributes';
 import { Entries } from '../types/entries.type';
+import { NodeSDK } from '@opentelemetry/sdk-node';
 
 export interface IOpenTelemetryBuilder {
   /**
@@ -218,20 +217,11 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
       traceExporter: this.tracingOptions.spanExporter,
       resource: this.resource,
       sampler: this.tracingOptions.sampler,
-      instrumentations: this.tracingOptions.instrumentations
+      instrumentations: this.tracingOptions.instrumentations,
+      spanProcessors: this.tracingOptions.spanProcessors
     });
 
     sdk.start();
-
-    GlobalProviders.tracerProvider = new NodeTracerProvider({
-      resource: this.resource
-    });
-
-    for (const processor of this.tracingOptions.spanProcessors) {
-      GlobalProviders.tracerProvider.addSpanProcessor(processor);
-    }
-
-    GlobalProviders.tracerProvider.register();
 
     if (this.isAtLeastDebugDiagLogLevel()) {
       console.debug('Tracing enabled.');

--- a/packages/open-telemetry-node/src/globals.ts
+++ b/packages/open-telemetry-node/src/globals.ts
@@ -1,11 +1,9 @@
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { MetricProvider } from './metrics/providers/metric.provider';
 import { MetricReader } from '@opentelemetry/sdk-metrics';
 
 export class GlobalProviders {
   public static logProvider: LoggerProvider | undefined;
-  public static tracerProvider: NodeTracerProvider;
   public static metricProvider: MetricProvider | undefined;
   public static metricReaders: MetricReader[] | undefined;
 }

--- a/packages/open-telemetry-node/src/tracing/decorators/span-attribute.decorator.spec.ts
+++ b/packages/open-telemetry-node/src/tracing/decorators/span-attribute.decorator.spec.ts
@@ -2,7 +2,7 @@ import { InvalidParameterAttributeError } from '../errors/invalid-parameter-attr
 import { spanAttribute } from './span-attribute.decorator';
 import { span } from './span.decorator';
 import { OpenTelemetryBuilder } from '../../core/builders/open-telemetry.builder';
-import { AlwaysOffSampler, InMemorySpanExporter, NoopSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { AlwaysOnSampler, InMemorySpanExporter, NoopSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { getSpanAttributes } from '../../../testing/util';
 import { trace } from '@opentelemetry/api';
 
@@ -10,7 +10,7 @@ describe('SpanAttributeDecorator', () => {
   beforeAll(() => {
     new OpenTelemetryBuilder('test')
       .withTracing(x =>
-        x.withSampler(new AlwaysOffSampler())
+        x.withSampler(new AlwaysOnSampler())
           .withSpanProcessor(_ => new NoopSpanProcessor())
           .withSpanExporter(new InMemorySpanExporter())
       ).start();

--- a/packages/open-telemetry-node/src/tracing/span/start-span.spec.ts
+++ b/packages/open-telemetry-node/src/tracing/span/start-span.spec.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import { startSpan } from './start-span';
 import { OpenTelemetryBuilder } from '../../core/builders/open-telemetry.builder';
-import { AlwaysOffSampler, InMemorySpanExporter, NoopSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { AlwaysOnSampler, InMemorySpanExporter, NoopSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { getSpanAttributes, getSpanName } from '../../../testing/util';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -12,7 +12,7 @@ describe('startSpan', () => {
   beforeAll(() => {
     new OpenTelemetryBuilder('test')
       .withTracing(x =>
-        x.withSampler(new AlwaysOffSampler())
+        x.withSampler(new AlwaysOnSampler())
           .withSpanProcessor(_ => new NoopSpanProcessor())
           .withSpanExporter(new InMemorySpanExporter())
       ).start();

--- a/packages/open-telemetry-node/src/tracing/tracer/get-tracer.ts
+++ b/packages/open-telemetry-node/src/tracing/tracer/get-tracer.ts
@@ -1,9 +1,9 @@
-import { GlobalProviders } from '../../globals';
 import { TRACER_NAME } from '../constants';
+import { trace } from '@opentelemetry/api';
 
 /**
  * Gets the current tracer.
  */
 export function getTracer() {
-  return GlobalProviders.tracerProvider?.getTracer(TRACER_NAME);
+  return trace?.getTracer(TRACER_NAME);
 }


### PR DESCRIPTION
Currently, the trace provider was initialized via the NodeSDK, as well as the NodeTraceProvider. This causes conflicts and error logs when starting up a project. This resolves this by letting the NodeSDK instantiate the trace provider.