### PR TITLE
docs(open-telemetry-node): add missing js doc

### DIFF
--- a/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
+++ b/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
@@ -36,8 +36,16 @@ export interface IOpenTelemetryBuilder {
    */
   withDebugLogging(): this;
 
+  /**
+   * Enables diagnostic logging with the specified level.
+   * @param level
+   */
   withDiagLogging(level: DiagLogLevel): this;
 
+  /**
+   * Configures logging with the specified options.
+   * @param optionsBuilderOrOptions either a builder function or the options object.
+   */
   withLogging(
     optionsBuilderOrOptions: OptionsBuilderOptions<
       IOpenTelemetryLoggingOptionsBuilder,
@@ -45,6 +53,10 @@ export interface IOpenTelemetryBuilder {
     >
   ): this;
 
+  /**
+   * Configures metrics with the specified options.
+   * @param optionsBuilderOrOptions either a builder function or the options object.
+   */
   withMetrics(
     optionsBuilderOrOptions: OptionsBuilderOptions<
       IOpenTelemetryMetricsOptionsBuilder,
@@ -52,6 +64,10 @@ export interface IOpenTelemetryBuilder {
     >
   ): this;
 
+  /**
+   * Configures tracing with the specified options.
+   * @param optionsBuilderOrOptions either a builder function or the options object.
+   */
   withTracing(
     optionsBuilderOrOptions: OptionsBuilderOptions<
       IOpenTelemetryTracingOptionsBuilder,
@@ -59,6 +75,9 @@ export interface IOpenTelemetryBuilder {
     >
   ): this;
 
+  /**
+   * Starts the OpenTelemetry SDK with the configured options.
+   */
   start(): void;
 }
 
@@ -73,6 +92,7 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
     this.resource = this.getResource();
   }
 
+  /** @inheritdoc */
   withDiagLogging(level: DiagLogLevel): this {
     this.diagLogLevel = level;
     return this;
@@ -90,6 +110,7 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
   public withLogging(
     options: OpenTelemetryLoggingOptions
   ): this;
+  /** @inheritdoc */
   public withLogging(
     optionsBuilderOrOptions: OptionsBuilderOptions<
       OpenTelemetryLoggingOptionsBuilder,
@@ -111,6 +132,7 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
   public withMetrics(
     options: OpenTelemetryMetricsOptions
   ): this;
+  /** @inheritdoc */
   public withMetrics(
     optionsBuilderOrOptions: OptionsBuilderOptions<
       OpenTelemetryMetricsOptionsBuilder,
@@ -132,6 +154,7 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
   public withTracing(
     options: OpenTelemetryTracingOptions
   ): this;
+  /** @inheritdoc */
   public withTracing(
     optionsBuilderOrOptions: OptionsBuilderOptions<
       OpenTelemetryTracingOptionsBuilder,
@@ -147,6 +170,7 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
     return this;
   }
 
+  /** @inheritdoc */
   public start(): void {
     this.tryEnableDiagLogging();
     this.tryEnableLogging();

--- a/packages/open-telemetry-node/src/core/models/options-builder.models.ts
+++ b/packages/open-telemetry-node/src/core/models/options-builder.models.ts
@@ -1,6 +1,14 @@
 export interface OptionsBuilder<T> {
+  /**
+   * Conditionally applies the provided function to the builder.
+   * @param condition true to apply the function, false to skip it.
+   * @param fn The function to apply.
+   */
   $if(condition: boolean, fn: OptionsBuilderFn<this>): this;
 
+  /**
+   * Builds the options object.
+   */
   build(): T;
 }
 

--- a/packages/open-telemetry-node/src/logging/builders/open-telemetry-logging-options.builder.ts
+++ b/packages/open-telemetry-node/src/logging/builders/open-telemetry-logging-options.builder.ts
@@ -6,10 +6,15 @@ import { LogRecordExporter } from '@opentelemetry/sdk-logs';
 
 export interface IOpenTelemetryLoggingOptionsBuilder
   extends OptionsBuilder<OpenTelemetryLoggingOptions> {
+  /**
+   * Adds a log record exporter to the options.
+   * @param exporter
+   */
   withLogRecordExporter(
     exporter: LogRecordExporter
   ): this;
 
+  /** @inheritdoc */
   build(): OpenTelemetryLoggingOptions;
 }
 
@@ -20,6 +25,7 @@ export class OpenTelemetryLoggingOptionsBuilder
     logRecordExporters: []
   };
 
+  /** @inheritdoc */
   public withLogRecordExporter(
     exporter: LogRecordExporter
   ): this {
@@ -29,6 +35,7 @@ export class OpenTelemetryLoggingOptionsBuilder
     return this;
   }
 
+  /** @inheritdoc */
   public $if(condition: boolean, fn: OptionsBuilderFn<this>): this {
     if (condition) {
       fn(this);
@@ -37,6 +44,7 @@ export class OpenTelemetryLoggingOptionsBuilder
     return this;
   }
 
+  /** @inheritdoc */
   public build(): OpenTelemetryLoggingOptions {
     const options = this.options;
     this.assertIsValidConfig(options);

--- a/packages/open-telemetry-node/src/logging/exporters/composite-log-record.exporter.ts
+++ b/packages/open-telemetry-node/src/logging/exporters/composite-log-record.exporter.ts
@@ -1,6 +1,9 @@
 import { ExportResult } from '@opentelemetry/core';
 import { LogRecordExporter, ReadableLogRecord } from '@opentelemetry/sdk-logs';
 
+/**
+ * An exporter that delegates to multiple exporters.
+ */
 export class CompositeLogRecordExporter implements LogRecordExporter {
   private readonly _exporters: LogRecordExporter[];
 
@@ -8,6 +11,7 @@ export class CompositeLogRecordExporter implements LogRecordExporter {
     this._exporters = exporters;
   }
 
+  /** @inheritdoc */
   public export(
     logs: ReadableLogRecord[],
     resultCallback: (result: ExportResult) => void
@@ -17,6 +21,7 @@ export class CompositeLogRecordExporter implements LogRecordExporter {
     }
   }
 
+  /** @inheritdoc */
   public async shutdown(): Promise<void> {
     await Promise.all(
       this._exporters.map((exporter) => exporter.shutdown())

--- a/packages/open-telemetry-node/src/metrics/builders/open-telemetry-metrics-options.builder.ts
+++ b/packages/open-telemetry-node/src/metrics/builders/open-telemetry-metrics-options.builder.ts
@@ -6,8 +6,15 @@ import { InvalidOptionsError } from '../../core/errors/invalid-options.error';
 
 export interface IOpenTelemetryMetricsOptionsBuilder
   extends OptionsBuilder<OpenTelemetryMetricsOptions> {
+  /**
+   * Allows adding default Prometheus metrics via the prom-client, that are not provided by OTEL.
+   */
   withDefaultMetrics(): this;
 
+  /**
+   * Adds a metric reader
+   * @param reader
+   */
   withMetricReader(reader: MetricReader): this;
 }
 
@@ -19,12 +26,14 @@ export class OpenTelemetryMetricsOptionsBuilder
     metricReaders: []
   };
 
+  /** @inheritdoc */
   public withDefaultMetrics(): this {
     this.options.collectDefaultMetrics = true;
 
     return this;
   }
 
+  /** @inheritdoc */
   public withMetricReader(
     reader: MetricReader
   ): this {
@@ -34,6 +43,7 @@ export class OpenTelemetryMetricsOptionsBuilder
     return this;
   }
 
+  /** @inheritdoc */
   public $if(condition: boolean, fn: OptionsBuilderFn<this>): this {
     if (condition) {
       fn(this);
@@ -42,7 +52,7 @@ export class OpenTelemetryMetricsOptionsBuilder
     return this;
   }
 
-
+  /** @inheritdoc */
   public build(): OpenTelemetryMetricsOptions {
     const options = this.options;
     this.assertIsValidConfig(options);

--- a/packages/open-telemetry-node/src/metrics/decorators/metric-increment.decorator.ts
+++ b/packages/open-telemetry-node/src/metrics/decorators/metric-increment.decorator.ts
@@ -1,5 +1,11 @@
 import { GlobalProviders } from '../../globals';
 
+/**
+ * Increments a Counter metric by provided value after a method has been invoked.
+ * @param name The name of the metric to increment.
+ * @param value The value to increment the metric by. Defaults to 1.
+ * @throws Error if the metric is not a counter.
+ */
 export function metricIncrement(
   name: string,
   value = 1

--- a/packages/open-telemetry-node/src/metrics/metrics/gauge.ts
+++ b/packages/open-telemetry-node/src/metrics/metrics/gauge.ts
@@ -1,9 +1,16 @@
 import { Attributes, Gauge as OTELGauge } from '@opentelemetry/api';
 
+/**
+ * Wrapper around the OTEL Gauge, to provide a more prom-client like API.
+ */
 export class Gauge {
   public constructor(private readonly gauge: OTELGauge<Attributes>) {
   }
 
+  /**
+   * Sets the gauge to the current time in seconds.
+   * @param attributes optional attributes to be set on the gauge.
+   */
   public setToCurrentTime(attributes?: Attributes): void {
     this.record(Date.now() / 1000, attributes);
   }
@@ -15,6 +22,11 @@ export class Gauge {
     this.gauge.record(value, attributes);
   }
 
+  /**
+   * Records the value to the gauge.
+   * @param value the value to record.
+   * @param attributes optional attributes to be set on the gauge.
+   */
   public record(value: number, attributes?: Attributes): void {
     this.gauge.record(value, attributes);
   }

--- a/packages/open-telemetry-node/src/metrics/metrics/get-or-create-metric.ts
+++ b/packages/open-telemetry-node/src/metrics/metrics/get-or-create-metric.ts
@@ -2,6 +2,7 @@ import { MetricOptions, MetricTypeMap } from '../models/metric-options.model';
 import { GlobalProviders } from '../../globals';
 
 /**
+ * Gets a metric if exists, otherwise creates a new metric.
  * @returns The metric if exists and open telemetry is initialized, otherwise null.
  */
 export const getOrCreateMetric = <

--- a/packages/open-telemetry-node/src/tracing/builders/open-telemetry-tracing-options.builder.ts
+++ b/packages/open-telemetry-node/src/tracing/builders/open-telemetry-tracing-options.builder.ts
@@ -7,20 +7,38 @@ import { Instrumentation } from '@opentelemetry/instrumentation/build/src/types'
 
 export interface IOpenTelemetryTracingOptionsBuilder
   extends OptionsBuilder<OpenTelemetryTracingOptions> {
+  /**
+   * Adds a sampler to the options.
+   * @param sampler
+   */
   withSampler(sampler: Sampler): this;
 
+  /**
+   * Adds a span exporter to the options.
+   * @param exporter
+   */
   withSpanExporter(
     exporter: SpanExporter
   ): this;
 
+  /**
+   * Adds instrumentation to the options.
+   * @param instrumentations
+   */
   withInstrumentation(
     ...instrumentations: Instrumentation[]
   ): this;
 
+  /**
+   * Adds a span processor to the options.
+   * Uses a factory instead of an instance to allow for late binding of the exporter.
+   * @param processorFactory
+   */
   withSpanProcessor(
     processorFactory: (exporter: SpanExporter) => SpanProcessor
   ): this;
 
+  /** @inheritdoc */
   build(): OpenTelemetryTracingOptions;
 }
 
@@ -37,12 +55,14 @@ export class OpenTelemetryTracingOptionsBuilder
   private processorFactories: ((exporter: SpanExporter) => SpanProcessor)[] =
     [];
 
+  /** @inheritdoc */
   public withSampler(sampler: Sampler): this {
     this.options.sampler = sampler;
 
     return this;
   }
 
+  /** @inheritdoc */
   public withSpanExporter(
     exporter: SpanExporter
   ): this {
@@ -51,6 +71,7 @@ export class OpenTelemetryTracingOptionsBuilder
     return this;
   }
 
+  /** @inheritdoc */
   public withInstrumentation(
     ...instrumentations: Instrumentation[]
   ): this {
@@ -60,6 +81,7 @@ export class OpenTelemetryTracingOptionsBuilder
     return this;
   }
 
+  /** @inheritdoc */
   public withSpanProcessor(
     processorFactory: (exporter: SpanExporter) => SpanProcessor
   ): this {
@@ -68,6 +90,7 @@ export class OpenTelemetryTracingOptionsBuilder
     return this;
   }
 
+  /** @inheritdoc */
   public $if(condition: boolean, fn: OptionsBuilderFn<this>): this {
     if (condition) {
       fn(this);
@@ -76,7 +99,7 @@ export class OpenTelemetryTracingOptionsBuilder
     return this;
   }
 
-
+  /** @inheritdoc */
   public build(): OpenTelemetryTracingOptions {
     const options = this.options;
     this.assertIsValidConfig(options);

--- a/packages/open-telemetry-node/src/tracing/decorators/root-span.decorator.ts
+++ b/packages/open-telemetry-node/src/tracing/decorators/root-span.decorator.ts
@@ -1,9 +1,18 @@
 import { SpanOptions } from '../models/span-options.model';
 import { span } from './span.decorator';
 
+/**
+ * Decorator to start a root span (new context) around a method.
+ * @param options
+ */
 export function rootSpan(
   options?: Exclude<SpanOptions, 'newContext'>
 ): MethodDecorator;
+/**
+ * Decorator to start a root span (new context) around a method.
+ * @param name
+ * @param options
+ */
 export function rootSpan(
   name?: string,
   options?: Exclude<SpanOptions, 'newContext'>

--- a/packages/open-telemetry-node/src/tracing/decorators/span-attribute.decorator.ts
+++ b/packages/open-telemetry-node/src/tracing/decorators/span-attribute.decorator.ts
@@ -3,21 +3,28 @@ import { SPAN_ATTRIBUTES } from '../constants';
 import { InvalidParameterAttributeError } from '../errors/invalid-parameter-attribute.error';
 import 'reflect-metadata';
 
+/**
+ * Automatically applies a parameter as an attribute to the active span.
+ * @remarks the method must be decorated with the {@link span} decorator for this to work
+ * @param name - the name for the span attribute, tries to default to the parameter name
+ * @param fn - primitives need no parsing, but if you want to convert the parameter to a string, number or boolean, provide a function
+ * @throws InvalidParameterAttributeError if no function is provided and the parameter is not a string, number or boolean (occurs before function invocation)
+ * @throws Error - if the provided function does not match the signature of the parameter (occurs when the function is invoked)
+ */
 export function spanAttribute<T>(
   name?: string,
   fn?: (param: T) => string | number | boolean
 ): ParameterDecorator;
-export function spanAttribute<T>(
-  fn?: (param: T) => string | number | boolean
-): ParameterDecorator;
 /**
- * Automatically applies a parameter as an attribute to the active span.
+ * Automatically applies a parameter as an attribute to the active span. Tries to default to the parameter name.
  * @remarks the method must be decorated with the {@link span} decorator for this to work
- * @param nameOrFn - either provide a name (defaults to parameter name) or a function to parse the parameter
- * @param fn - the function must match the signature of the parameter, or a runtime error may occur
+ * @param fn - primitives need no parsing, but if you want to convert the parameter to a string, number or boolean, provide a function
  * @throws InvalidParameterAttributeError if no function is provided and the parameter is not a string, number or boolean (occurs before function invocation)
  * @throws Error - if the provided function does not match the signature of the parameter (occurs when the function is invoked)
  */
+export function spanAttribute<T>(
+  fn?: (param: T) => string | number | boolean
+): ParameterDecorator;
 export function spanAttribute<T>(
   nameOrFn?: string | ((param: T) => string | number | boolean),
   fn?: (param: T) => string | number | boolean

--- a/packages/open-telemetry-node/src/tracing/decorators/span.decorator.ts
+++ b/packages/open-telemetry-node/src/tracing/decorators/span.decorator.ts
@@ -4,28 +4,55 @@ import { SPAN_ATTRIBUTES } from '../constants';
 import { SpanAttributeParameter } from '../models/span-attribute-parameter.model';
 import { getTracer } from '../tracer/get-tracer';
 
-export function span(options?: SpanOptions): MethodDecorator;
-export function span(name?: string, options?: SpanOptions): MethodDecorator;
 /**
  * Decorator to start a span around a method.
  * To avoid less clutter within methods, this decorator can be used instead of startSpan.
+ * The span name will be ClassName::methodName if no name is provided.
  * @example
+ * ```typescript
  *  class MyClass {
  *    @span('my-method', { myAttribute: 'myValue' })
  *    myMethod() {
  *    // do something
  *    }
  *   }
+ * ```
  * @example
+ * ```typescript
  *  class MyClass {
  *    @span()
  *    myMethod() {
  *      // do something
  *    }
  *   }
- * @param nameOrOptions name if string, options if object
- * @param options options if name is string
+ * ```
+ * @param options
  */
+export function span(options?: SpanOptions): MethodDecorator;
+/**
+ * Decorator to start a span around a method.
+ * To avoid less clutter within methods, this decorator can be used instead of startSpan.
+ * The span name will be ClassName::methodName if no name is provided.
+ * @example
+ * ```typescript
+ *  class MyClass {
+ *    @span('my-method', { myAttribute: 'myValue' })
+ *    myMethod() {
+ *    // do something
+ *    }
+ *   }
+ * ```
+ * @example
+ * ```typescript
+ *  class MyClass {
+ *    @span()
+ *    myMethod() {
+ *      // do something
+ *    }
+ *   }
+ * ```
+ */
+export function span(name?: string, options?: SpanOptions): MethodDecorator;
 export function span(
   nameOrOptions?: string | SpanOptions,
   options?: SpanOptions

--- a/packages/open-telemetry-node/src/tracing/span/set-attributes-on-active-span.ts
+++ b/packages/open-telemetry-node/src/tracing/span/set-attributes-on-active-span.ts
@@ -1,5 +1,10 @@
 import { AttributeValue, trace } from '@opentelemetry/api';
 
+/**
+ * Sets an attribute on the active span.
+ * @param key
+ * @param value
+ */
 export const setAttributeOnActiveSpan = (
   key: string,
   value: AttributeValue
@@ -7,6 +12,10 @@ export const setAttributeOnActiveSpan = (
   trace.getActiveSpan()?.setAttribute(key, value);
 };
 
+/**
+ * Sets attributes on the active span.
+ * @param attributes
+ */
 export const setAttributesOnActiveSpan = (
   attributes: Record<string, AttributeValue>
 ) => {

--- a/packages/open-telemetry-node/src/tracing/span/start-active-span.ts
+++ b/packages/open-telemetry-node/src/tracing/span/start-active-span.ts
@@ -2,6 +2,12 @@ import { context, ROOT_CONTEXT, Span, trace } from '@opentelemetry/api';
 import { SpanOptions } from '../models/span-options.model';
 import { getTracer } from '../tracer/get-tracer';
 
+/**
+ * Starts an active span.
+ * @param name
+ * @param fn
+ * @param options
+ */
 export const startActiveSpan = (
   name: string,
   fn: (parentSpan: Span) => void,


### PR DESCRIPTION
Added missing JSdocs documentation to the node package. Additionally, fixed documentation not automatically added on function overloads.