### PR TITLE
refactor(open-telemetry-node): remove deprecated methods

### DIFF
--- a/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
+++ b/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
@@ -31,12 +31,6 @@ import { MeterProvider } from '@opentelemetry/sdk-metrics';
 
 export interface IOpenTelemetryBuilder {
   /**
-   * @deprecated - will be removed in v1.1, use {@link withDiagLogging} instead.
-   *  for identical behaviour use `withDiagLogging(DiagLogLevel.DEBUG)`
-   */
-  withDebugLogging(): this;
-
-  /**
    * Enables diagnostic logging with the specified level.
    * @param level
    */
@@ -95,12 +89,6 @@ export class OpenTelemetryBuilder implements IOpenTelemetryBuilder {
   /** @inheritdoc */
   withDiagLogging(level: DiagLogLevel): this {
     this.diagLogLevel = level;
-    return this;
-  }
-
-  /** @inheritdoc */
-  public withDebugLogging(): this {
-    this.diagLogLevel = DiagLogLevel.DEBUG;
     return this;
   }
 

--- a/packages/open-telemetry-node/src/metrics/metrics/gauge.spec.ts
+++ b/packages/open-telemetry-node/src/metrics/metrics/gauge.spec.ts
@@ -24,58 +24,6 @@ describe('Gauge', () => {
     jest.useFakeTimers().setSystemTime(currentDate.getTime());
   });
 
-  describe('set', () => {
-    it('should set the correct count and attributes when set is called', async () => {
-      // Arrange
-      const value = 5;
-      const attributes = { test: 'test' };
-
-      // Act
-      gauge?.set(value, attributes);
-
-      // Assert
-      const metrics = await getMetrics();
-      const metricDescriptor = metrics?.descriptor;
-      expect(metricDescriptor?.name).toEqual(metricName);
-
-      const dataPoints = metrics?.dataPoints;
-      expect(dataPoints).toHaveLength(1);
-
-      const gaugeData = dataPoints?.[0];
-      expect(gaugeData?.value).toEqual(value);
-      expect(gaugeData?.attributes).toEqual(attributes);
-    });
-
-    it('should set multiple data points for the same metric when set is called multiple times with different attributes', async () => {
-      // Arrange
-      const attributes2 = { test: 'test' };
-      const attributes3 = { test: 'test2' };
-
-      // Act
-      gauge?.set(1);
-      gauge?.set(2, attributes2);
-      gauge?.set(3, attributes3);
-
-      // Assert
-      const metrics = await getMetrics();
-      const metricDescriptor = metrics?.descriptor;
-      expect(metricDescriptor?.name).toEqual(metricName);
-
-      const dataPoints = metrics?.dataPoints;
-      expect(dataPoints).toHaveLength(3);
-
-      const [gaugeData, gaugeData2, gaugeData3] = dataPoints ?? [];
-      expect(gaugeData?.value).toEqual(1);
-      expect(gaugeData?.attributes).toEqual({});
-
-      expect(gaugeData2?.value).toEqual(2);
-      expect(gaugeData2?.attributes).toEqual(attributes2);
-
-      expect(gaugeData3?.value).toEqual(3);
-      expect(gaugeData3?.attributes).toEqual(attributes3);
-    });
-  });
-
   describe('record', () => {
     it('should set the correct count and attributes when set is called', async () => {
       // Arrange

--- a/packages/open-telemetry-node/src/metrics/metrics/gauge.ts
+++ b/packages/open-telemetry-node/src/metrics/metrics/gauge.ts
@@ -16,13 +16,6 @@ export class Gauge {
   }
 
   /**
-   * @deprecated use {@link record} instead. Will be removed in version 1.1.
-   */
-  public set(value: number, attributes?: Attributes): void {
-    this.gauge.record(value, attributes);
-  }
-
-  /**
    * Records the value to the gauge.
    * @param value the value to record.
    * @param attributes optional attributes to be set on the gauge.


### PR DESCRIPTION
Removed methods that were marked as deprecated per v1.1, which will be the next release:

- `withDebugLogging` has been replaced by `withDiagLogging` to better align with the OTEL spec.
- The `set` method has been removed from the Gauge wrapper, `record` should be used instead to align more with the OTEL spec.