### PR TITLE
feat: use diag error logging for uninitialized providers

### DIFF
--- a/packages/open-telemetry-nest/src/logging/adapters/nest-winston-logger.adapter.ts
+++ b/packages/open-telemetry-nest/src/logging/adapters/nest-winston-logger.adapter.ts
@@ -3,7 +3,7 @@ import { Logger } from 'winston';
 import { GlobalProviders } from '@zonneplan/open-telemetry-node';
 import { LogAttributes, SeverityNumber } from '@opentelemetry/api-logs';
 import { LoggerService } from '../services/logger.service';
-import { context } from '@opentelemetry/api';
+import { context, diag } from '@opentelemetry/api';
 import {
   NEST_LOG_LEVEL_WINSTON_SEVERITY,
   SEVERITY_NUMBER_TO_TEXT_MAP,
@@ -126,7 +126,7 @@ export class NestWinstonLoggerAdapter extends LoggerService {
     }
 
     if (!GlobalProviders.logProvider) {
-      console.error('OpenTelemetry log provider not initialized');
+      diag.error('OpenTelemetry log provider not initialized');
       return;
     }
 

--- a/packages/open-telemetry-node/src/metrics/metrics/get-or-create-metric.ts
+++ b/packages/open-telemetry-node/src/metrics/metrics/get-or-create-metric.ts
@@ -1,5 +1,6 @@
 import { MetricOptions, MetricTypeMap } from '../models/metric-options.model';
 import { GlobalProviders } from '../../globals';
+import { diag } from '@opentelemetry/api';
 
 /**
  * Gets a metric if exists, otherwise creates a new metric.
@@ -12,7 +13,7 @@ export const getOrCreateMetric = <
   options: MetricOptions<TMetricType>
 ): TMetric | null => {
   if (!GlobalProviders.metricProvider) {
-    console.error('OpenTelemetry metrics are not initialized');
+    diag.error('OpenTelemetry metrics are not initialized');
     return null;
   }
 


### PR DESCRIPTION
Use the diagnostics logging from OTEL, so that the logs are not sent unless the user explicitly wants to see the errors.

closes #42 