### PR TITLE
fix: Use exported types only

### DIFF
--- a/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
+++ b/packages/open-telemetry-node/src/core/builders/open-telemetry.builder.ts
@@ -22,12 +22,10 @@ import {
 import { logs } from '@opentelemetry/api-logs';
 import { CompositeLogRecordExporter } from '../../logging/exporters/composite-log-record.exporter';
 import { GlobalProviders } from '../../globals';
-import {
-  SEMRESATTRS_SERVICE_NAME
-} from '@opentelemetry/semantic-conventions/build/src/resource/SemanticResourceAttributes';
 import { Entries } from '../types/entries.type';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 export interface IOpenTelemetryBuilder {
   /**

--- a/packages/open-telemetry-node/src/metrics/models/metric-options.model.ts
+++ b/packages/open-telemetry-node/src/metrics/models/metric-options.model.ts
@@ -1,5 +1,5 @@
 import { Counter, Histogram } from '@opentelemetry/api';
-import { MetricOptions as OtelMetricOptions } from '@opentelemetry/api/build/src/metrics/Metric';
+import { MetricOptions as OtelMetricOptions } from '@opentelemetry/api';
 import { Gauge } from '../metrics/gauge';
 
 export type MetricTypeMap = {

--- a/packages/open-telemetry-node/src/tracing/builders/open-telemetry-tracing-options.builder.ts
+++ b/packages/open-telemetry-node/src/tracing/builders/open-telemetry-tracing-options.builder.ts
@@ -3,7 +3,7 @@ import { Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-b
 import { OpenTelemetryTracingOptions } from '../models/tracing-options.model';
 import * as assert from 'assert';
 import { InvalidOptionsError } from '../../core/errors/invalid-options.error';
-import { Instrumentation } from '@opentelemetry/instrumentation/build/src/types';
+import { Instrumentation } from '@opentelemetry/instrumentation';
 
 export interface IOpenTelemetryTracingOptionsBuilder
   extends OptionsBuilder<OpenTelemetryTracingOptions> {

--- a/packages/open-telemetry-node/src/tracing/models/span-options.model.ts
+++ b/packages/open-telemetry-node/src/tracing/models/span-options.model.ts
@@ -1,4 +1,4 @@
-import { SpanOptions as OTELSpanOptions } from '@opentelemetry/api/build/src/trace/SpanOptions';
+import { SpanOptions as OTELSpanOptions } from '@opentelemetry/api';
 
 export interface SpanOptions extends OTELSpanOptions {
   /**

--- a/packages/open-telemetry-node/src/tracing/models/tracing-options.model.ts
+++ b/packages/open-telemetry-node/src/tracing/models/tracing-options.model.ts
@@ -1,5 +1,5 @@
 import { Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { Instrumentation } from '@opentelemetry/instrumentation/build/src/types';
+import { Instrumentation } from '@opentelemetry/instrumentation';
 
 export interface OpenTelemetryTracingOptions {
   sampler: Sampler;


### PR DESCRIPTION
This should fix this error i got (Nx 20.3.x):

```
Error: Package subpath './build/src/resource/SemanticResourceAttributes' is not defined by "exports" in [...]/node_modules/@opentelemetry/semantic-conventions/package.json
```