### PR TITLE
feat(open-telemetry-node): Add ObservableGauge

### DIFF
--- a/packages/open-telemetry-node/src/metrics/models/metric-options.model.ts
+++ b/packages/open-telemetry-node/src/metrics/models/metric-options.model.ts
@@ -1,4 +1,4 @@
-import { Counter, Histogram } from '@opentelemetry/api';
+import { Counter, Histogram, ObservableGauge } from '@opentelemetry/api';
 import { MetricOptions as OtelMetricOptions } from '@opentelemetry/api';
 import { Gauge } from '../metrics/gauge';
 
@@ -6,6 +6,7 @@ export type MetricTypeMap = {
   Gauge: Gauge;
   Counter: Counter;
   Histogram: Histogram;
+  ObservableGauge: ObservableGauge;
 };
 
 export type Metrics = MetricTypeMap[MetricType];

--- a/packages/open-telemetry-node/src/metrics/providers/metric.provider.spec.ts
+++ b/packages/open-telemetry-node/src/metrics/providers/metric.provider.spec.ts
@@ -94,4 +94,18 @@ describe('MetricProvider', () => {
       expect(metric1).toBe(metric2);
     });
   });
+
+  it('should return an observable gauge when provided with observable gauge options', () => {
+    // Arrange
+    const options: MetricOptions<'ObservableGauge'> = {
+      name: 'test',
+      type: 'ObservableGauge'
+    };
+
+    // Act
+    const metric = metricProvider.getOrCreateMetric(options);
+
+    // Assert
+    expect(metric).toHaveProperty('addCallback');
+  });
 });

--- a/packages/open-telemetry-node/src/metrics/providers/metric.provider.ts
+++ b/packages/open-telemetry-node/src/metrics/providers/metric.provider.ts
@@ -38,6 +38,9 @@ export class MetricProvider {
       case 'Histogram':
         metric = this.meter.createHistogram(name, opts) as TMetric;
         break;
+      case 'ObservableGauge':
+        metric = this.meter.createObservableGauge(name, opts) as TMetric;
+        break;
       default:
         throw new Error(`Unknown metric type: ${opts.type}`);
     }


### PR DESCRIPTION
We replaced our version of the ObservableGauge with the sync version when it became available ([reference](https://github.com/zonneplan/open-telemetry-js/pull/22)). 

This PR allows to use both versions.

