### PR TITLE
chore(docker-compose): add volume mount for grafana 

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,7 +3,7 @@ name: open-telemetry-grafana
 
 services:
   grafana:
-    image: grafana/grafana:10.4.0-ubuntu
+    image: grafana/grafana:latest-ubuntu
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -19,7 +19,7 @@ services:
       - loki
 
   grafana-agent:
-    image: grafana/agent:v0.40.3
+    image: grafana/agent:latest
     volumes:
       - ./grafana-agent/grafana-agent.river:/etc/agent/config.river:ro
     environment:
@@ -38,7 +38,7 @@ services:
       - prometheus
 
   loki:
-    image: grafana/loki:2.9.5
+    image: grafana/loki:latest
     volumes:
       - ./loki/loki.yaml:/etc/loki/loki.yaml:ro
     command:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -4,6 +4,7 @@ name: open-telemetry-grafana
 services:
   grafana:
     image: grafana/grafana:latest-ubuntu
+    pull_policy: always
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -23,6 +24,7 @@ services:
     image: grafana/agent:latest
     volumes:
       - ./grafana-agent/grafana-agent.river:/etc/agent/config.river:ro
+    pull_policy: always
     environment:
       - AGENT_MODE=flow
     command:
@@ -42,6 +44,7 @@ services:
     image: grafana/loki:latest
     volumes:
       - ./loki/loki.yaml:/etc/loki/loki.yaml:ro
+    pull_policy: always
     command:
       - '-config.file=/etc/loki/loki.yaml'
     ports:
@@ -51,6 +54,7 @@ services:
     image: prom/prometheus:latest
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    pull_policy: always
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--web.enable-remote-write-receiver'
@@ -61,6 +65,7 @@ services:
     image: grafana/tempo:latest
     volumes:
       - ./tempo/tempo.yaml:/etc/tempo.yaml
+    pull_policy: always
     command:
       - '-config.file=/etc/tempo.yaml'
     ports:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./grafana/datasources.yaml:/etc/grafana/provisioning/datasources/ds.yaml:ro
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
+      - grafana-data:/var/lib/grafana
     ports:
       - "3000:3000"
     depends_on:
@@ -64,3 +65,6 @@ services:
       - '-config.file=/etc/tempo.yaml'
     ports:
       - 3200:3200
+
+volumes:
+  grafana-data:


### PR DESCRIPTION
- Set all images to use the latest version.
- Added a volume mount for Grafana so that created dashboards and other settings remain.