### PR TITLE
chore(docker-compose): add pyroscope for continuous profiling

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - prometheus
       - tempo
       - loki
+      - pyroscope
 
   grafana-alloy:
     image: grafana/alloy:latest
@@ -68,5 +69,16 @@ services:
     ports:
       - 3200:3200
 
+  pyroscope:
+    image: grafana/pyroscope:latest
+    pull_policy: always
+    ports:
+      - "4040:4040"
+    command:
+      - 'server'
+    volumes:
+      - pyroscope-data:/var/lib/pyroscope
+
 volumes:
   grafana-data:
+  pyroscope-data:

--- a/docker-compose/grafana-alloy/config.river
+++ b/docker-compose/grafana-alloy/config.river
@@ -6,6 +6,12 @@ livedebugging {
   enabled = true
 }
 
+pyroscope.write "default" {
+  endpoint {
+    url = "http://pyroscope:4040"
+  }
+}
+
 otelcol.receiver.otlp "default" {
   grpc {
     endpoint = "0.0.0.0:4317"

--- a/docker-compose/grafana/datasources.yaml
+++ b/docker-compose/grafana/datasources.yaml
@@ -56,3 +56,17 @@ datasources:
       manageAlerts: true
       prometheusType: Prometheus
       disableRecordingRules: false
+
+
+  - name: Pyroscope
+    uid: pyroscope_uid
+    type: grafana-pyroscope-datasource
+    access: proxy
+    orgId: 1
+    url: http://pyroscope:4040
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    jsonData:
+      minStep: '15s'


### PR DESCRIPTION
## Summary

Adds Grafana Pyroscope to the local docker-compose observability stack for continuous profiling.

- New `pyroscope` service (`grafana/pyroscope:latest`) exposed on `4040`, with a `pyroscope-data` volume and added as a Grafana dependency.
- Grafana Alloy now ships profiles to Pyroscope via a `pyroscope.write "default"` endpoint.
- New `Pyroscope` Grafana datasource so profiles are queryable from the dashboards.

## Test plan

- `docker compose up` brings the stack up with the new `pyroscope` service healthy on `:4040`.
- Pyroscope datasource is available in Grafana and receives profile data from Alloy.