### PR TITLE
feat(metrics): add ObservableCounter support to getOrCreateMetric

### DIFF
--- a/packages/open-telemetry-node/src/metrics/index.ts
+++ b/packages/open-telemetry-node/src/metrics/index.ts
@@ -1,4 +1,9 @@
-import { Counter, Histogram } from '@opentelemetry/api';
+import {
+  Counter,
+  Histogram,
+  ObservableCounter,
+  ObservableGauge,
+} from '@opentelemetry/api';
 
 // Builders
 export {
@@ -11,7 +16,7 @@ export { metricIncrement } from './decorators/metric-increment.decorator';
 
 // Metrics
 export { Gauge } from './metrics/gauge';
-export type { Counter, Histogram };
+export type { Counter, Histogram, ObservableGauge, ObservableCounter };
 export { getOrCreateMetric } from './metrics/get-or-create-metric';
 
 // Models

--- a/packages/open-telemetry-node/src/metrics/models/metric-options.model.ts
+++ b/packages/open-telemetry-node/src/metrics/models/metric-options.model.ts
@@ -1,4 +1,9 @@
-import { Counter, Histogram, ObservableGauge } from '@opentelemetry/api';
+import {
+  Counter,
+  Histogram,
+  ObservableCounter,
+  ObservableGauge,
+} from '@opentelemetry/api';
 import { MetricOptions as OtelMetricOptions } from '@opentelemetry/api';
 import { Gauge } from '../metrics/gauge';
 
@@ -7,6 +12,7 @@ export type MetricTypeMap = {
   Counter: Counter;
   Histogram: Histogram;
   ObservableGauge: ObservableGauge;
+  ObservableCounter: ObservableCounter;
 };
 
 export type Metrics = MetricTypeMap[MetricType];

--- a/packages/open-telemetry-node/src/metrics/providers/metric.provider.spec.ts
+++ b/packages/open-telemetry-node/src/metrics/providers/metric.provider.spec.ts
@@ -107,4 +107,18 @@ describe('MetricProvider', () => {
     // Assert
     expect(metric).toHaveProperty('addCallback');
   });
+
+  it('should return an observable counter when provided with observable counter options', () => {
+    // Arrange
+    const options: MetricOptions<'ObservableCounter'> = {
+      name: 'test',
+      type: 'ObservableCounter',
+    };
+
+    // Act
+    const metric = metricProvider.getOrCreateMetric(options);
+
+    // Assert
+    expect(metric).toHaveProperty('addCallback');
+  });
 });

--- a/packages/open-telemetry-node/src/metrics/providers/metric.provider.ts
+++ b/packages/open-telemetry-node/src/metrics/providers/metric.provider.ts
@@ -41,6 +41,9 @@ export class MetricProvider {
       case 'ObservableGauge':
         metric = this.meter.createObservableGauge(name, opts) as TMetric;
         break;
+      case 'ObservableCounter':
+        metric = this.meter.createObservableCounter(name, opts) as TMetric;
+        break;
       default:
         throw new Error(`Unknown metric type: ${opts.type}`);
     }


### PR DESCRIPTION
## What

Adds `ObservableCounter` to the metrics abstraction, alongside the existing `ObservableGauge`.

- `ObservableCounter` added to `MetricTypeMap` and the `getOrCreateMetric` provider switch (`meter.createObservableCounter`).
- `ObservableGauge` / `ObservableCounter` types exported from the metrics index.
- New provider test for the branch.

## Why

Enables consumers to export cumulative lifetime totals as **observable** counters that report absolute running total, letting the OTel SDK derive the per-interval increment and handle resets — instead of hand-rolling delta bookkeeping. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)